### PR TITLE
change -EOS.undent -> ~EOS

### DIFF
--- a/armitage.rb
+++ b/armitage.rb
@@ -11,11 +11,11 @@ class Armitage < Formula
 
   def install
     libexec.install Dir['*']
-    (bin/"armitage").write <<-EOS.undent
+    (bin/"armitage").write <<~EOS
       #!/bin/sh
       cd #{libexec} && ./armitage "$@"
     EOS
-    (bin/"teamserver").write <<-EOS.undent
+    (bin/"teamserver").write <<~EOS
       #!/bin/sh
       cd #{libexec} && ./teamserver "$@"
     EOS

--- a/cewl.rb
+++ b/cewl.rb
@@ -30,13 +30,13 @@ class Cewl < Formula
     inreplace "cewl.rb", "require './cewl_lib'", "require '#{libexec}/cewl_lib'"
     inreplace "fab.rb", "require \"./cewl_lib.rb\"", "require '#{libexec}/cewl_lib.rb'"
 
-    (bin/"cewl.rb").write <<-EOS.undent
+    (bin/"cewl.rb").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{libexec}/vendor/bundle"
       export BUNDLE_GEMFILE="#{libexec}/Gemfile"
       #{libexec}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{libexec}/cewl.rb "$@"
     EOS
-    (bin/"fab.rb").write <<-EOS.undent
+    (bin/"fab.rb").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{libexec}/vendor/bundle"
       export BUNDLE_GEMFILE="#{libexec}/Gemfile"

--- a/metasploit-framework.rb
+++ b/metasploit-framework.rb
@@ -38,12 +38,12 @@ class MetasploitFramework < Formula
            "--no-cache", "--path", "vendor/bundle"
 
     if build.with? "oracle"
-      (buildpath/"Gemfile.local").write <<-EOS.undent
+      (buildpath/"Gemfile.local").write <<~EOS
       group :local do
         gem 'ruby-oci8', '~> 2.2.3'
       end
       EOS
-      (buildpath/"Gemfile.local.lock").write <<-EOS.undent
+      (buildpath/"Gemfile.local.lock").write <<~EOS
       GEM
         remote: https://rubygems.org/
         specs:
@@ -63,55 +63,55 @@ class MetasploitFramework < Formula
              "--path", "vendor/bundle"
     end
 
-    (bin/"msfbinscan").write <<-EOS.undent
+    (bin/"msfbinscan").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
       #{pkgshare}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{pkgshare}/msfbinscan "$@"
     EOS
-    (bin/"msfconsole").write <<-EOS.undent
+    (bin/"msfconsole").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
       #{pkgshare}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{pkgshare}/msfconsole "$@"
     EOS
-    (bin/"msfd").write <<-EOS.undent
+    (bin/"msfd").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
       #{pkgshare}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{pkgshare}/msfd "$@"
     EOS
-    (bin/"msfelfscan").write <<-EOS.undent
+    (bin/"msfelfscan").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
       #{pkgshare}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{pkgshare}/msfelfscan "$@"
     EOS
-    (bin/"msfmachscan").write <<-EOS.undent
+    (bin/"msfmachscan").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
       #{pkgshare}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{pkgshare}/msfmachscan "$@"
     EOS
-    (bin/"msfpescan").write <<-EOS.undent
+    (bin/"msfpescan").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
       #{pkgshare}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{pkgshare}/msfpescan "$@"
     EOS
-    (bin/"msfrop").write <<-EOS.undent
+    (bin/"msfrop").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
       #{pkgshare}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{pkgshare}/msfrop "$@"
     EOS
-    (bin/"msfrpc").write <<-EOS.undent
+    (bin/"msfrpc").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
       #{pkgshare}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{pkgshare}/msfrpc "$@"
     EOS
-    (bin/"msfrpcd").write <<-EOS.undent
+    (bin/"msfrpcd").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
@@ -123,7 +123,7 @@ class MetasploitFramework < Formula
     #  export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"
     #  #{pkgshare}/vendor/bundle/bin/bundle exec #{HOMEBREW_PREFIX}/opt/ruby@2.3/bin/ruby #{pkgshare}/msfupdate "$@"
     #EOS
-    (bin/"msfvenom").write <<-EOS.undent
+    (bin/"msfvenom").write <<~EOS
       #!/usr/bin/env bash
       export GEM_HOME="#{pkgshare}/vendor/bundle"
       export BUNDLE_GEMFILE="#{pkgshare}/Gemfile"


### PR DESCRIPTION
brew fails as 'undent' is disabled (after being deprecated for a while). I changed these formulas per $SUBJECT.

Homebrew: 1.6.3
Ruby: 2.5.1p57
OS: MacOS 10.13.3